### PR TITLE
remove hardcoded paths to python3

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 dirpo4md=$(dirname "$0")
-/usr/bin/python3 ${dirpo4md}/tools/poc.py
+python3 ${dirpo4md}/tools/poc.py

--- a/update.sh
+++ b/update.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 dirpo4md=$(dirname "$0")
-/usr/bin/python3 ${dirpo4md}/tools/createpot.py
-/usr/bin/python3 ${dirpo4md}/tools/updatepo.py
+python3 ${dirpo4md}/tools/createpot.py
+python3 ${dirpo4md}/tools/updatepo.py


### PR DESCRIPTION
Enable compiling on different OS (e.g., Mac an Linux) including local python installations (provided that python3 can be found in the $PATH).